### PR TITLE
Custom authentication backends to support email/username for login

### DIFF
--- a/codeclassroom/settings.py
+++ b/codeclassroom/settings.py
@@ -102,6 +102,12 @@ DATABASES = {
     }
 }
 
+# Authentication
+
+AUTHENTICATION_BACKENDS = (
+    'utilities.backends.UsernameOrEmailBackend',
+    'django.contrib.auth.backends.ModelBackend'
+)
 
 # Password validation
 # https://docs.djangoproject.com/en/2.2/ref/settings/#auth-password-validators

--- a/utilities/backends.py
+++ b/utilities/backends.py
@@ -7,6 +7,7 @@ UserModel = get_user_model()
 
 
 class UsernameOrEmailBackend(ModelBackend):
+
     def authenticate(self, request, username=None, password=None, **kwargs):
         if username is None:
             username = kwargs.get(UserModel.USERNAME_FIELD)

--- a/utilities/backends.py
+++ b/utilities/backends.py
@@ -1,0 +1,32 @@
+"""Custom authentication backends to support email/username for login"""
+
+from django.contrib.auth.backends import ModelBackend
+from django.contrib.auth import get_user_model
+
+UserModel = get_user_model()
+
+
+class UsernameOrEmailBackend(ModelBackend):
+    def authenticate(self, request, username=None, password=None, **kwargs):
+        if username is None:
+            username = kwargs.get(UserModel.USERNAME_FIELD)
+
+        if '@' in username:
+            kwargs = {'email': username}
+        else:
+            kwargs = {'username': username}
+        try:
+            user = UserModel.objects.get(**kwargs)
+        except UserModel.DoesNotExist:
+            return None
+
+        if user.check_password(password) and self.user_can_authenticate(user):
+            return user
+
+    def get_user(self, user_id):
+        try:
+            user = UserModel.objects.get(pk=user_id)
+        except UserModel.DoesNotExist:
+            return None
+
+        return user if self.user_can_authenticate(user) else None


### PR DESCRIPTION
Changes:
Created backends.py to support custom authentication backends to support email/username for login  

Tested in my local setup:
I was able to login using my test account email
![Screen Shot 2020-10-28 at 2 00 17 PM](https://user-images.githubusercontent.com/19628734/97592323-c1733b80-19bd-11eb-9147-c17287eb8e56.png)
 
References:
https://rahmanfadhil.com/django-login-with-email/
https://stackoverflow.com/questions/44972983/allowing-both-email-and-username-login-in-django-project
